### PR TITLE
INFRA-242 500 Error on CC when openpgp enabled

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -8,7 +8,7 @@ Redmine::Plugin.register :openpgp do
   name 'OpenPGP'
   author 'Alexander Blum'
   description 'Email encryption with the OpenPGP standard'
-  version '1.0'
+  version '1.0.1'
   author_url 'mailto:a.blum@free-reality.net'
   url 'https://github.com/C3S/redmine_openpgp'
   settings(:default => {

--- a/lib/encrypt_mails.rb
+++ b/lib/encrypt_mails.rb
@@ -118,11 +118,16 @@ module EncryptMails
       [:to, :cc].each do |field|
         headers[field].each do |user|
 
-          # encrypted
-          if Pgpkey.find_by(user_id: user.id).nil?
-            logger.info "No public key found for #{user} <#{user.mail}> (#{user.id})" if logger
-          else
-            recipients[:encrypted][field].push user and next
+          # Try to catch case where an email was passed where the address isnt a current user
+          begin
+            # encrypted
+            if Pgpkey.find_by(user_id: user.id).nil?
+              logger.info "No public key found for #{user} <#{user.mail}> (#{user.id})" if logger
+            else
+              recipients[:encrypted][field].push user and next
+            end
+          rescue NoMethodError
+            logger.info "Tried to encrypt non-system user #{user}"
           end
 
           # unencrypted


### PR DESCRIPTION
When adding a CC address that is not a current system user, the openpgp plugin would
throw a 500 error with the following msg in the logs:

```
NoMethodError (undefined method `id' for ["xxxxxxxxxx@xxxxx"]:Array):            
  plugins/openpgp/lib/encrypt_mails.rb:122:in `block (2 levels) in relocate_recipients'
  plugins/openpgp/lib/encrypt_mails.rb:119:in `each'               
  plugins/openpgp/lib/encrypt_mails.rb:119:in `block in relocate_recipients'         
  plugins/openpgp/lib/encrypt_mails.rb:118:in `each'
  plugins/openpgp/lib/encrypt_mails.rb:118:in `relocate_recipients'                                     
  plugins/openpgp/lib/encrypt_mails.rb:45:in `mail_with_relocation
```

Added a basic exception handling block to handle this situation. Doesn't seem to pose any
leakage of information if the openpgp settings are on `filtered`.